### PR TITLE
fix(utils): ensure reference folder

### DIFF
--- a/utils/convert.js
+++ b/utils/convert.js
@@ -504,6 +504,10 @@ function buildParamDocs(docs) {
   out.end();
 }
 
-fs.writeFileSync(path.join(__dirname, '../docs/reference/data.json'), JSON.stringify(converted, null, 2));
-fs.writeFileSync(path.join(__dirname, '../docs/reference/data.min.json'), JSON.stringify(converted));
+const folder = path.join(__dirname, '../docs/reference');
+
+if (!fs.existsSync(folder)) fs.mkdirSync(folder);
+
+fs.writeFileSync(path.join(folder, 'data.json'), JSON.stringify(converted, null, 2));
+fs.writeFileSync(path.join(folder, 'data.min.json'), JSON.stringify(converted));
 buildParamDocs(JSON.parse(JSON.stringify(converted)));


### PR DESCRIPTION
Hey there,

as the title says, this commit just adds some code to ensure that output folder `docs/reference` exists. Otherwise the script will throw an error.
